### PR TITLE
Added optional session to all API calls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -245,6 +245,29 @@ Error Handling
 When dweepy encounters an error a ``DweepyError`` exception is raised. This can happen either when a HTTP request to the dweet.io API fails with an invalid status code, or if the HTTP request succeeds but the request fails for some reason (invalid key, malformed request data, invalid action etc.).
 
 
+Request Sessions
+~~~~~~~~~~~~~~~~
+
+Each API call allows a request ``Session`` to be optionally set to persist certain parameters across dweepy calls. Sessions can be used for:
+
+* reusing the the underlying TCP connection if you're making several requests to the same host
+* configuring HTTP Proxies
+* enabling timeouts for HTTP requests
+
+Further information of requests session can be found in `Request Session Advanced Usage <http://docs.python-requests.org/en/master/user/advanced/>`_.
+
+To enable a session (in this case with a 5 second timeout)::
+
+    >>> import requests
+    >>> session_with_timeout = requests.session(timeout=5.0)
+
+
+The session may be used in all dweepy API calls::
+
+    >>> dweepy.dweet({'some_key': 'some_value'}, session=session_with_timeout)
+    >>> dweepy.dweet_for('this_is_a_thing', {'some_key': 'some_value'}, session=session_with_timeout)
+
+
 Testing
 -------
 

--- a/dweepy/api.py
+++ b/dweepy/api.py
@@ -26,11 +26,15 @@ class DweepyError(Exception):
     pass
 
 
-def _request(method, url, **kwargs):
+def _request(method, url, session=None, **kwargs):
     """Make HTTP request, raising an exception if it fails.
     """
     url = BASE_URL + url
-    request_func = getattr(requests, method)
+
+    if session:
+        request_func = getattr(session, method)
+    else:
+        request_func = getattr(requests, method)
     response = request_func(url, **kwargs)
     # raise an exception if request is not successful
     if not response.status_code == requests.codes.ok:
@@ -41,85 +45,85 @@ def _request(method, url, **kwargs):
     return response_json['with']
 
 
-def _send_dweet(payload, url, params=None):
+def _send_dweet(payload, url, params=None, session=None):
     """Send a dweet to dweet.io
     """
     data = json.dumps(payload)
     headers = {'Content-type': 'application/json'}
-    return _request('post', url, data=data, headers=headers, params=params)
+    return _request('post', url, data=data, headers=headers, params=params, session=session)
 
 
-def dweet(payload):
+def dweet(payload, session=None):
     """Send a dweet to dweet.io without naming your thing
     """
-    return _send_dweet(payload, '/dweet')
+    return _send_dweet(payload, '/dweet', session=session)
 
 
-def dweet_for(thing_name, payload, key=None):
+def dweet_for(thing_name, payload, key=None, session=None):
     """Send a dweet to dweet.io for a thing with a known name
     """
     if key is not None:
         params = {'key': key}
     else:
         params = None
-    return _send_dweet(payload, '/dweet/for/{0}'.format(thing_name), params=params)
+    return _send_dweet(payload, '/dweet/for/{0}'.format(thing_name), params=params, session=session)
 
 
-def get_latest_dweet_for(thing_name, key=None):
+def get_latest_dweet_for(thing_name, key=None, session=None):
     """Read the latest dweet for a dweeter
     """
     if key is not None:
         params = {'key': key}
     else:
         params = None
-    return _request('get', '/get/latest/dweet/for/{0}'.format(thing_name), params=params)
+    return _request('get', '/get/latest/dweet/for/{0}'.format(thing_name), params=params, session=session)
 
 
-def get_dweets_for(thing_name, key=None):
+def get_dweets_for(thing_name, key=None, session=None):
     """Read all the dweets for a dweeter
     """
     if key is not None:
         params = {'key': key}
     else:
         params = None
-    return _request('get', '/get/dweets/for/{0}'.format(thing_name), params=params)
+    return _request('get', '/get/dweets/for/{0}'.format(thing_name), params=params, session=None)
 
 
-def remove_lock(lock, key):
+def remove_lock(lock, key, session=None):
     """Remove a lock (no matter what it's connected to).
     """
-    return _request('get', '/remove/lock/{0}'.format(lock), params={'key': key})
+    return _request('get', '/remove/lock/{0}'.format(lock), params={'key': key}, session=session)
 
 
-def lock(thing_name, lock, key):
+def lock(thing_name, lock, key, session=None):
     """Lock a thing (prevents unauthed dweets for the locked thing)
     """
-    return _request('get', '/lock/{0}'.format(thing_name), params={'key': key, 'lock': lock})
+    return _request('get', '/lock/{0}'.format(thing_name), params={'key': key, 'lock': lock}, session=session)
 
 
-def unlock(thing_name, key):
+def unlock(thing_name, key, session=None):
     """Unlock a thing
     """
-    return _request('get', '/unlock/{0}'.format(thing_name), params={'key': key})
+    return _request('get', '/unlock/{0}'.format(thing_name), params={'key': key}, session=session)
 
 
-def set_alert(thing_name, who, condition, key):
+def set_alert(thing_name, who, condition, key, session=None):
     """Set an alert on a thing with the given condition
     """
     return _request('get', '/alert/{0}/when/{1}/{2}'.format(
         ','.join(who),
         thing_name,
         quote(condition),
-    ), params={'key': key})
+    ), params={'key': key}, session=session)
 
 
-def get_alert(thing_name, key):
+def get_alert(thing_name, key, session=None):
     """Set an alert on a thing with the given condition
     """
-    return _request('get', '/get/alert/for/{0}'.format(thing_name), params={'key': key})
+    return _request('get', '/get/alert/for/{0}'.format(thing_name), params={'key': key}, session=session)
 
 
-def remove_alert(thing_name, key):
+def remove_alert(thing_name, key, session=None):
     """Remove an alert for the given thing
     """
-    return _request('get', '/remove/alert/for/{0}'.format(thing_name), params={'key': key})
+    return _request('get', '/remove/alert/for/{0}'.format(thing_name), params={'key': key}, session=session)

--- a/dweepy/streaming.py
+++ b/dweepy/streaming.py
@@ -54,11 +54,11 @@ def _listen_for_dweets_from_response(response):
             streambuffer = ''
 
 
-def listen_for_dweets_from(thing_name, timeout=900, key=None):
+def listen_for_dweets_from(thing_name, timeout=900, key=None, session=None):
     """Create a real-time subscription to dweets
     """
     url = BASE_URL + '/listen/for/dweets/from/{0}'.format(thing_name)
-    session = requests.Session()
+    session = session or requests.Session()
     if key is not None:
         params = {'key': key}
     else:


### PR DESCRIPTION
An optional session parameter has been added to all API call to enable
the reuse of existing request sessions. This can be used to reduce the
overhead incurred from establishing HTTP/HTTPS connections, and to
allow the callers to take advantage of the features of the request
session.

The addition of the session parameter has been introduced to preserve
backwards compatibility with the existing API calls.
