### PR TITLE
Increase chunk size to accommodate large dweets

### DIFF
--- a/dweepy/streaming.py
+++ b/dweepy/streaming.py
@@ -43,7 +43,10 @@ def _listen_for_dweets_from_response(response):
     """
     streambuffer = ''
     for byte in response.iter_content():
-        if byte:
+        if not byte:
+            break
+            
+        else:
             streambuffer += byte.decode('ascii')
             try:
                 dweet = json.loads(streambuffer.splitlines()[1])

--- a/dweepy/streaming.py
+++ b/dweepy/streaming.py
@@ -42,7 +42,7 @@ def _listen_for_dweets_from_response(response):
     """Yields dweets as received from dweet.io's streaming API
     """
     streambuffer = ''
-    for byte in response.iter_content(chunk_size=50):
+    for byte in response.iter_content(chunk_size=2000):
         if not byte:
             break
             

--- a/dweepy/streaming.py
+++ b/dweepy/streaming.py
@@ -42,7 +42,7 @@ def _listen_for_dweets_from_response(response):
     """Yields dweets as received from dweet.io's streaming API
     """
     streambuffer = ''
-    for byte in response.iter_content():
+    for byte in response.iter_content(chunk_size=50):
         if not byte:
             break
             

--- a/dweepy/streaming.py
+++ b/dweepy/streaming.py
@@ -43,10 +43,7 @@ def _listen_for_dweets_from_response(response):
     """
     streambuffer = ''
     for byte in response.iter_content(chunk_size=2000):
-        if not byte:
-            break
-            
-        else:
+        if byte:
             streambuffer += byte.decode('ascii')
             try:
                 dweet = json.loads(streambuffer.splitlines()[1])


### PR DESCRIPTION
Dweet content over 48 characters long crashes the stream. This change increases capacity to 2000 characters to reflect the actual size limit of dweets. Fixes #17